### PR TITLE
fix tzf init and bump tzf/tzf-rel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/kelvins/sunrisesunset v0.0.0-20210220141756-39fa1bd816d5
-	github.com/ringsaturn/tzf v0.6.0
-	github.com/ringsaturn/tzf-rel v0.0.2021-c
+	github.com/ringsaturn/tzf v0.7.0
+	github.com/ringsaturn/tzf-rel v0.0.2021-c2
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,10 +5,10 @@ github.com/kelvins/sunrisesunset v0.0.0-20210220141756-39fa1bd816d5 h1:ouekCqYkM
 github.com/kelvins/sunrisesunset v0.0.0-20210220141756-39fa1bd816d5/go.mod h1:3oZ7G+fb8Z8KF+KPHxeDO3GWpEjgvk/f+d/yaxmDRT4=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/ringsaturn/tzf v0.6.0 h1:AtWBdlIIyJUIjNPjp/sMEbh5u0B2ddPLBRnYwaUWIwU=
-github.com/ringsaturn/tzf v0.6.0/go.mod h1:7IvX0j8ZcN3BMD/zpc79Cc6nUV/UmCPuGNq1Gv6Rt44=
-github.com/ringsaturn/tzf-rel v0.0.2021-c h1:KydSjORjgAKpRYW1qU6tosVUto7ki4yEJeHnmV3WrPs=
-github.com/ringsaturn/tzf-rel v0.0.2021-c/go.mod h1:TvyUIUpF3aCH98QYjTmMb1cqK7pFswdFLoIVZwGNV/M=
+github.com/ringsaturn/tzf v0.7.0 h1:/hR6pBsbbaWyzLzCPqOlyfE0+V9Dds41mFE4wwvtzVg=
+github.com/ringsaturn/tzf v0.7.0/go.mod h1:gAZPmC3inOeCR/5PU+MED714yYZqXmif18f4f6sQEl0=
+github.com/ringsaturn/tzf-rel v0.0.2021-c2 h1:4wQEDA5gImMfw6JwvRHbSqBQfBx8omsUfvsTT92vwAo=
+github.com/ringsaturn/tzf-rel v0.0.2021-c2/go.mod h1:TvyUIUpF3aCH98QYjTmMb1cqK7pFswdFLoIVZwGNV/M=
 github.com/tidwall/cities v0.1.0/go.mod h1:lV/HDp2gCcRcHJWqgt6Di54GiDrTZwh1aG2ZUPNbqa4=
 github.com/tidwall/geoindex v1.4.4/go.mod h1:rvVVNEFfkJVWGUdEfU8QaoOg/9zFX0h9ofWzA60mz1I=
 github.com/tidwall/geojson v1.3.5 h1:7fg+XBI0Xx08fFDtggJIUBNGVL8ccey+klZN6keUETo=
@@ -23,6 +23,5 @@ github.com/tidwall/sjson v1.2.4/go.mod h1:098SZ494YoMWPmMO6ct4dcFnqxwj9r/gF0Etp1
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/nighttime.go
+++ b/nighttime.go
@@ -11,6 +11,18 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var finder *tzf.Finder
+
+func init() {
+	input := &pb.Timezones{}
+
+	dataFile := tzfrel.LiteData
+	if err := proto.Unmarshal(dataFile, input); err != nil {
+		return
+	}
+	finder, _ = tzf.NewFinderFromPB(input)
+}
+
 type Place struct {
 	Lat  float64
 	Lon  float64
@@ -88,14 +100,9 @@ func (place *Place) GetZone() (*time.Location, float64) {
 	defaultLocation, _ := time.LoadLocation(zone)
 	defaultOffset := float64(offset / 3600)
 
-	// get data
-	input := &pb.Timezones{}
-
-	dataFile := tzfrel.LiteData
-	if err := proto.Unmarshal(dataFile, input); err != nil {
+	if finder == nil {
 		return defaultLocation, defaultOffset
 	}
-	finder, _ := tzf.NewFinderFromPB(input)
 
 	// get time zone name by coordinates
 	timeZone := finder.GetTimezoneName(place.Lon, place.Lat)


### PR DESCRIPTION
1. tzf’s finder default init is slow, could be seconds, so use a package level var and `init` func for it
2. bump tzf/tzf-rel version for [v0.7.0](https://github.com/ringsaturn/tzf/releases/tag/v0.7.0) fixed hole in polygon problem
